### PR TITLE
Changed ls from printing full path length to individual files

### DIFF
--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -2,6 +2,7 @@ use dev_term_io::command_io;
 use dev_term_io::Executable;
 use walkdir::WalkDir;
 use std::path::PathBuf;
+
 command_io! {
     struct Ls: "Displays the current files in a directory", "ls" {
         pub path: Option<String>, "the path to inspect!",

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -36,7 +36,7 @@ impl Executable for Ls {
             None => 1,
         };
         for entry in WalkDir::new(&path).max_depth(depth) {
-            println!("{}", entry?.path().display());
+            println!("{}", entry?.file_name().to_str());
         }
         Ok(())
     }

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -1,7 +1,7 @@
 use dev_term_io::command_io;
 use dev_term_io::Executable;
-use walkdir::WalkDir;
 use std::path::PathBuf;
+use walkdir::WalkDir;
 
 command_io! {
     struct Ls: "Displays the current files in a directory", "ls" {
@@ -15,28 +15,37 @@ impl Executable for Ls {
     fn execute(&self) -> std::io::Result<()> {
         let path = match &self.path {
             Some(p) => PathBuf::from(p),
-            None => std::env::current_dir()?
+            None => std::env::current_dir()?,
         };
         let depth = match &self.flag {
-            Some(d) => {
-                match &**d {
-                    "-d" | "--depth" => {
-                        match self.depth {
-                            Some(de) => de as usize,
-                            None => {
-                                return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Expected non negative integer depth!"));
-                            }
-                        }
+            Some(d) => match &**d {
+                "-d" | "--depth" => match self.depth {
+                    Some(de) => de as usize,
+                    None => {
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            "Expected non negative integer depth!",
+                        ));
                     }
-                    _ => {
-                        return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("Expected a valid flag found: {}!", d)));
-                    }
+                },
+                _ => {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidInput,
+                        format!("Expected a valid flag found: {}!", d),
+                    ));
                 }
             },
             None => 1,
         };
         for entry in WalkDir::new(&path).max_depth(depth) {
-            println!("{}", entry?.path().strip_prefix(path.as_path().clone()).unwrap().display());
+            println!(
+                "{}",
+                entry?
+                    .path()
+                    .strip_prefix(path.as_path())
+                    .unwrap()
+                    .display()
+            );
         }
         Ok(())
     }

--- a/src/commands/ls.rs
+++ b/src/commands/ls.rs
@@ -2,7 +2,6 @@ use dev_term_io::command_io;
 use dev_term_io::Executable;
 use walkdir::WalkDir;
 use std::path::PathBuf;
-
 command_io! {
     struct Ls: "Displays the current files in a directory", "ls" {
         pub path: Option<String>, "the path to inspect!",
@@ -36,7 +35,7 @@ impl Executable for Ls {
             None => 1,
         };
         for entry in WalkDir::new(&path).max_depth(depth) {
-            println!("{}", entry?.file_name().to_str());
+            println!("{}", entry?.path().strip_prefix(path.as_path().clone()).unwrap().display());
         }
         Ok(())
     }


### PR DESCRIPTION
Because ls printed out the full path it was really verbose, so i removed that so now it will only print out the file names